### PR TITLE
Fix migrations to deploy correct Solidity contract

### DIFF
--- a/migrations/2_deploy_contract.js
+++ b/migrations/2_deploy_contract.js
@@ -1,4 +1,4 @@
-const GravatarRegistry = artifacts.require('./GravatarRegistry.sol')
+const GravatarRegistry = artifacts.require('./Gravity.sol')
 
 module.exports = async function(deployer) {
   await deployer.deploy(GravatarRegistry)

--- a/migrations/3_create_gravatars.js
+++ b/migrations/3_create_gravatars.js
@@ -1,4 +1,4 @@
-const GravatarRegistry = artifacts.require('./GravatarRegistry.sol')
+const GravatarRegistry = artifacts.require('./Gravity.sol')
 
 module.exports = async function(deployer) {
   const registry = await GravatarRegistry.deployed()


### PR DESCRIPTION
## Summary
- correct file path for GravatarRegistry contract
- update migrations to use the actual Solidity filename

## Testing
- `npm run build-contract` *(fails: solc not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843408dc9a48322879752e356874ac5